### PR TITLE
Make s-c/build/cmake.sh a plain sh(1) script for better portability.

### DIFF
--- a/build/cmake.sh
+++ b/build/cmake.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 
-# Editable Variables
-CMAKE_COMMAND=cmake
+# You may override these from the environment
+: ${CMAKE_COMMAND:=cmake}
 
 ###############################################################################
 
-if [ -z "$(type -p $CMAKE_COMMAND)" ] ; then
-	echo "You have to install CMake"
+if [ -z "$($CMAKE_COMMAND) --version" ] ; then
+	echo "You have to install CMake" >&2
 	exit 1
 fi
 
@@ -20,36 +20,36 @@ mecho()
 ###############################################################################
 
 if [ ! -e bin ] ; then
-	mecho --blue "Creating symlink «bin» ..."
+	mecho --blue "Creating symlink 'bin' ..."
 	ln -s . bin
 fi
 
 if [ ! -e RTTR ] ; then
 	if [ -e ../RTTR ] ; then
-		mecho --blue "Creating symlink «RTTR» ..."
+		mecho --blue "Creating symlink 'RTTR' ..."
 		ln -s ../RTTR RTTR
 	else
-		mecho --red "Directory «RTTR» missing!"
+		mecho --red "Directory 'RTTR' missing!"
 		exit 1
 	fi
 fi
 
 if [ ! -e share ] ; then
-	mecho --blue "Creating symlink «share» ..."
+	mecho --blue "Creating symlink 'share' ..."
 	ln -s . share
 fi
 
 if [ ! -e s25rttr ] ; then
-	mecho --blue "Creating symlink «s25rttr» ..."
+	mecho --blue "Creating symlink 's25rttr' ..."
 	ln -s . s25rttr
 fi
 
 if [ ! -e S2 ] ; then
 	if [ -e ../S2 ] ; then
-		mecho --blue "Creating symlink «S2» ..."
+		mecho --blue "Creating symlink 'S2' ..."
 	ln -s ../S2 S2
 	else
-		mecho --red "Directory «S2» missing!"
+		mecho --red "Directory 'S2' missing!"
 		exit 1
 	fi
 fi
@@ -62,11 +62,11 @@ if [ -z "$ARCH" ] ; then
 	fi
 fi
 
-if ( [ ! -f cleanup.sh ] && [ -f ../build/cleanup.sh ] ) ; then
+if [ ! -f cleanup.sh ] && [ -f ../build/cleanup.sh ] ; then
 	ln -s ../build/cleanup.sh cleanup.sh
 fi
 
-if ( [ ! -f cmake.sh ] && [ -f ../build/cmake.sh ] ) ; then
+if [ ! -f cmake.sh ] && [ -f ../build/cmake.sh ] ; then
 	ln -s ../build/cmake.sh cmake.sh
 fi
 
@@ -100,7 +100,7 @@ while test $# != 0 ; do
 		$ac_shift
 		PREFIX=$ac_optarg
 	;;
-        -iprefix | --iprefix)
+	-iprefix | --iprefix)
 		$ac_shift
 		IPREFIX=$ac_optarg
 	;;
@@ -116,22 +116,22 @@ while test $# != 0 ; do
 		$ac_shift
 		ARCH=$ac_optarg
 	;;
-  	-enable-* | --enable-*)
-    	ac_feature=`expr "x$ac_option" : 'x-*enable-\([^=]*\)'`
-    	# Reject names that are not valid shell variable names.
-    	expr "x$ac_feature" : ".*[^-._$as_cr_alnum]" >/dev/null &&
-      	{
-      		echo "error: invalid feature name: $ac_feature" >&2
-   			{ (exit 1); exit 1; };
-   		}
-    	ac_feature=`echo $ac_feature | sed 's/[-.]/_/g'`
-    	if [ -z "$ac_optarg" ] ; then
-    		ac_optarg="yes"
-    		echo foo
-    	fi
-    	eval enable_$ac_feature=\$ac_optarg
-    ;;
-    *)
+	-enable-* | --enable-*)
+	ac_feature=`expr "x$ac_option" : 'x-*enable-\([^=]*\)'`
+	# Reject names that are not valid shell variable names.
+	expr "x$ac_feature" : ".*[^-._$as_cr_alnum]" >/dev/null &&
+	{
+		echo "error: invalid feature name: $ac_feature" >&2
+			{ (exit 1); exit 1; };
+		}
+	ac_feature=`echo $ac_feature | sed 's/[-.]/_/g'`
+	if [ -z "$ac_optarg" ] ; then
+		ac_optarg="yes"
+		echo foo
+	fi
+	eval enable_$ac_feature=\$ac_optarg
+	;;
+	*)
 		echo "Unknown option: $ac_option"
 		exit 1
 	;;
@@ -172,13 +172,13 @@ echo "Setting Data Dir to \"$DATADIR\""
 PARAMS="$PARAMS -DDATADIR=$DATADIR"
 
 case "$enable_debug" in
-yes|YES|Yes)
+[Yy][Ee][Ss])
 	mecho --magenta "Activating debug build"
 	PARAMS="$PARAMS -DCMAKE_BUILD_TYPE=Debug"
 ;;
 *)
 	case "$enable_reldeb" in
-	yes|YES|Yes)
+	[Yy][Ee][Ss])
 		mecho --magenta "Activating release build with debug information"
 		PARAMS="$PARAMS -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 	;;


### PR DESCRIPTION
While here, remove 8bit chars to make it UTF-8, remove some unneeded
subshells, leading spaces and allow all possible spellings of 'yes'.
